### PR TITLE
Slightly corrected version

### DIFF
--- a/node.py
+++ b/node.py
@@ -1,8 +1,10 @@
-from PIL import Image, ImageOps
-from io import BytesIO
-import numpy as np
-import requests
 import time
+import base64
+import requests
+import numpy as np
+
+from io import BytesIO
+from PIL import Image, ImageOps
 
 #You can use this node to save full size images through the websocket, the
 #images will be sent in exactly the same format as the image previews: as
@@ -32,7 +34,10 @@ class SendHttpRequest:
         for image in images:
             i = 255. * image.cpu().numpy()
             img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
-            requests.post(url,data=img)
+            rawBytes = BytesIO()
+            img.save(rawBytes, "PNG")
+            rawBytes.seek(0)
+            requests.post(url,data={'img': base64.b64encode(rawBytes.read()).decode('utf-8')})
             step += 1
 
         return {}


### PR DESCRIPTION
The problem with the main version is that it sends "raw" bytes without everything, although it is more correct to send JSON with an image in the form of **base64**, which I implemented

```traceback
Traceback (most recent call last):
  File "/home/Jacob/ComfyUI/execution.py", line 323, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "/home/Jacob/ComfyUI/execution.py", line 198, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "/home/Jacob/ComfyUI/execution.py", line 169, in _map_node_over_list
    process_inputs(input_dict, i)
  File "/home/Jacob/ComfyUI/execution.py", line 158, in process_inputs
    results.append(getattr(obj, func)(**inputs))
  File "/home/Jacob/ComfyUI/custom_nodes/comfy_http_request/node.py", line 35, in save_images
    requests.post(url,data=img)
  File "/home/Jacob/.pyenv/versions/AI/lib/python3.10/site-packages/requests/api.py", line 115, in post
    return request("post", url, data=data, json=json, **kwargs)
  File "/home/Jacob/.pyenv/versions/AI/lib/python3.10/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/Jacob/.pyenv/versions/AI/lib/python3.10/site-packages/requests/sessions.py", line 575, in request
    prep = self.prepare_request(req)
  File "/home/Jacob/.pyenv/versions/AI/lib/python3.10/site-packages/requests/sessions.py", line 484, in prepare_request
    p.prepare(
  File "/home/Jacob/.pyenv/versions/AI/lib/python3.10/site-packages/requests/models.py", line 370, in prepare
    self.prepare_body(data, files, json)
  File "/home/Jacob/.pyenv/versions/AI/lib/python3.10/site-packages/requests/models.py", line 564, in prepare_body
    self.prepare_content_length(body)
  File "/home/Jacob/.pyenv/versions/AI/lib/python3.10/site-packages/requests/models.py", line 575, in prepare_content_length
    length = super_len(body)
  File "/home/Jacob/.pyenv/versions/AI/lib/python3.10/site-packages/requests/utils.py", line 189, in super_len
    o.seek(0, 2)
TypeError: Image.seek() takes 2 positional arguments but 3 were given
```
The problem here is most likely that `Image.seek` takes slightly different parameters than `dict`, which `requests.post` automatically converts to a `JSON Object`

In any case, this problem has been fixed!